### PR TITLE
Use pseudo after element for shadow

### DIFF
--- a/assets/css/highlight.css
+++ b/assets/css/highlight.css
@@ -90,12 +90,24 @@ code {
     #figure-container {
       background: var(--main-bg-color) !important;
       * { border-color: var(--main-color) !important; }
-      transition: box-shadow .3s ease;
-      box-shadow: 1ch 1ch var(--box-shadow);
+      position: relative;
+
+      &::after {
+        content: '';
+        position: absolute;
+        inset: 0;
+        translate: 1ch 1ch;
+        background: var(--box-shadow);
+        transition: translate .3s ease;
+        z-index: -1;
+      }
     }
 
     #figure-container:hover {
-      box-shadow: .5ch .5ch var(--box-shadow);
+      &::after {
+        translate: 0.5ch 0.5ch;
+      }
+
       a {
         text-decoration: underline;
       }


### PR DESCRIPTION
<img width="683" alt="Screenshot 2025-05-13 at 9 22 57 PM" src="https://github.com/user-attachments/assets/d7d72cbd-ff6d-49ac-8246-93f6464b78c2" />

Noticed an artifact in Safari 18.4 when hovering snippets.

Using a pseudo element seems to get rid of it.

I sort of tested it. Installing ruby was like wut?
